### PR TITLE
Change requirements for django-mptt to avoid breaking on django-1.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-django-mptt>=0.6,<0.7
+django-mptt>=0.6
 unicode-slugify==0.1.1


### PR DESCRIPTION
Installing by default the latest version of django-mptt
