### PR TITLE
fix: replace deprecated load staticfiles with static, fix use of cycle syntax

### DIFF
--- a/categories/templates/admin/edit_inline/gen_coll_tabular.html
+++ b/categories/templates/admin/edit_inline/gen_coll_tabular.html
@@ -1,4 +1,4 @@
-{% load i18n staticfiles %}
+{% load i18n static %}
 <div class="inline-group">
 	<div class="tabular inline-related {% if forloop.last %}last-related{% endif %}">
 		{{ inline_admin_formset.formset.management_form }}
@@ -17,7 +17,7 @@
 					{% if inline_admin_form.form.non_field_errors %}
 						<tr><td colspan="{{ inline_admin_form.field_count }}">{{ inline_admin_form.form.non_field_errors }}</td></tr>
 					{% endif %}
-					<tr class="{% cycle row1,row2 %} {% if inline_admin_form.original or inline_admin_form.show_url %}has_original{% endif %}">
+					<tr class="{% cycle row1 row2 %} {% if inline_admin_form.original or inline_admin_form.show_url %}has_original{% endif %}">
 						<td class="original">
 							{% if inline_admin_form.original or inline_admin_form.show_url %}<p>
 								{% if inline_admin_form.original %} {{ inline_admin_form.original.content_object }}{% endif %}


### PR DESCRIPTION
Fix to make `django-categories` work with Django 3.x / 3.1.x