### PR TITLE
fix/update testing

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -8,7 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.6, 3.7, 3.8, 3.9, '3.10' ]
+        python-version: [ 3.7, 3.8, 3.9, '3.10', '3.11', '3.12' ]
+      fail-fast: false
 
     steps:
       - uses: actions/checkout@v1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         additional_dependencies: [toml]

--- a/categories/tests/test_views.py
+++ b/categories/tests/test_views.py
@@ -25,15 +25,15 @@ class TestCategoryViews(TestCase):
         cat2 = Category.objects.get(slug="urban-cowboy")
         url = cat0.get_absolute_url()
         response = self.client.get(url)
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         url = cat1.get_absolute_url()
         response = self.client.get(url)
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         url = cat2.get_absolute_url()
         response = self.client.get(url)
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         response = self.client.get("%sfoo/" % url)
-        self.assertEquals(response.status_code, 404)
+        self.assertEqual(response.status_code, 404)
 
     def test_get_category_for_path(self):
         cat0 = Category.objects.get(slug="country", level=0)
@@ -41,11 +41,11 @@ class TestCategoryViews(TestCase):
         cat2 = Category.objects.get(slug="urban-cowboy")
 
         result = views.get_category_for_path("/country/country-pop/urban-cowboy/")
-        self.assertEquals(result, cat2)
+        self.assertEqual(result, cat2)
         result = views.get_category_for_path("/country/country-pop/")
-        self.assertEquals(result, cat1)
+        self.assertEqual(result, cat1)
         result = views.get_category_for_path("/country/")
-        self.assertEquals(result, cat0)
+        self.assertEqual(result, cat0)
 
     def test_categorydetailview(self):
         request = self.factory.get("")
@@ -55,7 +55,7 @@ class TestCategoryViews(TestCase):
         request = self.factory.get("")
         request.user = AnonymousUser()
         response = views.CategoryDetailView.as_view()(request, path="/country/country-pop/urban-cowboy/")
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
         request = self.factory.get("")
         request.user = AnonymousUser()
@@ -74,7 +74,7 @@ class TestCategoryViews(TestCase):
         request = self.factory.get("")
         request.user = AnonymousUser()
         response = MyCategoryRelationView.as_view()(request, category_path="/country/country-pop/urban-cowboy/")
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
         request = self.factory.get("")
         request.user = AnonymousUser()

--- a/tox.ini
+++ b/tox.ini
@@ -2,10 +2,12 @@
 envlist =
     begin
     py36-lint
-    py{36,37,38,39}-django{2}
-    py{36,37,38,39,310}-django{21,22,3,31,32}
+    py{36,37}-django{2,21}
+    py{36,37,38,39}-django{22,3,31}
+    py{36,37,38,39,310}-django{32}
     py{38,39,310}-django{40}
-    py{38,39,310}-django{41}
+    py{38,39,310,311}-django{41}
+    py{310,311,312}-django{42,50}
     coverage-report
 
 [gh-actions]
@@ -15,6 +17,7 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
 
 [testenv]
 passenv = GITHUB_*
@@ -27,7 +30,9 @@ deps=
     django31: Django>=3.1,<3.2
     django32: Django>=3.2,<4.0
     django40: Django>=4.0,<4.1
-    django41: Django>=4.1,<5.0
+    django41: Django>=4.1,<4.2
+    django42: Django>=4.2,<5.0
+    django50: Django>=5.0,<5.1
     coverage[toml]
     pillow
     ipdb


### PR DESCRIPTION
- don't test in Python 3.6 unsupported  by GitHub actions
- update testing matrix
- update `isort` in pre-commit to fix testing