### PR TITLE
remove dependency on unicode-slugify, use Django builtin function

### DIFF
--- a/categories/base.py
+++ b/categories/base.py
@@ -12,10 +12,10 @@ from django.utils.translation import gettext_lazy as _
 from mptt.fields import TreeForeignKey
 from mptt.managers import TreeManager
 from mptt.models import MPTTModel
-from slugify import slugify
 
 from .editor.tree_editor import TreeEditor
 from .settings import ALLOW_SLUG_CHANGE, SLUG_TRANSLITERATOR
+from .utils import slugify
 
 
 class CategoryManager(models.Manager):

--- a/categories/management/commands/import_categories.py
+++ b/categories/management/commands/import_categories.py
@@ -2,10 +2,11 @@
 
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
-from slugify import slugify
 
 from categories.models import Category
 from categories.settings import SLUG_TRANSLITERATOR
+
+from ...utils import slugify
 
 
 class Command(BaseCommand):

--- a/categories/tests/test_utils.py
+++ b/categories/tests/test_utils.py
@@ -1,0 +1,24 @@
+from django.test import TestCase
+
+from ..utils import slugify
+
+
+class TestSlugify(TestCase):
+    def test_slugify(self):
+        string_dict = {
+            "naïve café": "naïve-café",
+            "spaced    out": "spaced-out",
+            "user@domain.com": "userdomaincom",
+            "100% natural": "100-natural",
+            "über-cool": "über-cool",
+            "façade élégant": "façade-élégant",
+            "北京大学": "北京大学",
+            "Толстой": "толстой",
+            "ñoño": "ñoño",
+            "سلام": "سلام",
+            "Αθήνα": "αθήνα",
+            "こんにちは": "こんにちは",
+            "˚č$'\\*>%ˇ'!/": "čˇ",
+        }
+        for key, value in string_dict.items():
+            self.assertEqual(slugify(key), value)

--- a/categories/utils.py
+++ b/categories/utils.py
@@ -1,0 +1,8 @@
+"""This module contains utility functions that are used across the project."""
+
+from django.utils.text import slugify as django_slugify
+
+
+def slugify(text):
+    """Slugify a string. This function is a wrapper to unify the slugify function across the project."""
+    return django_slugify(text, allow_unicode=True)

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,2 +1,1 @@
 django-mptt
-unicode-slugify


### PR DESCRIPTION
Use `django.utils.text.slugify` with `allow_unicode=True` and remove `unicode-slugify` dependency (which causes conflicts with `python-slugify` and seems to be unnecessary.

